### PR TITLE
Rename projectriff/buildpack to projectriff/builder

### DIFF
--- a/.travis/create-builder.sh
+++ b/.travis/create-builder.sh
@@ -5,4 +5,4 @@ set -o nounset
 set -o pipefail
 
 
-pack create-builder -b builder-riff.toml projectriff/buildpack:latest
+pack create-builder -b builder-riff.toml projectriff/builder:latest

--- a/.travis/push-buildtemplate-to-gcs.sh
+++ b/.travis/push-buildtemplate-to-gcs.sh
@@ -7,8 +7,8 @@ set -o pipefail
 version=`cat VERSION`
 gcloud auth activate-service-account --key-file <(echo $GCLOUD_CLIENT_SECRET | base64 --decode)
 
-docker push projectriff/buildpack:${version}-ci-${TRAVIS_COMMIT}
-sed "s|projectriff/buildpack:latest|projectriff/buildpack:${version}-ci-${TRAVIS_COMMIT}|" riff-cnb-buildtemplate.yaml > riff-cnb-buildtemplate-${version}-ci-${TRAVIS_COMMIT}.yaml
+docker push projectriff/builder:${version}-ci-${TRAVIS_COMMIT}
+sed "s|projectriff/builder:latest|projectriff/builder:${version}-ci-${TRAVIS_COMMIT}|" riff-cnb-buildtemplate.yaml > riff-cnb-buildtemplate-${version}-ci-${TRAVIS_COMMIT}.yaml
 
 gsutil cp -a public-read riff-cnb-buildtemplate-${version}-ci-${TRAVIS_COMMIT}.yaml gs://projectriff/riff-buildtemplate/
 gsutil cp -a public-read riff-cnb-buildtemplate.yaml gs://projectriff/riff-buildtemplate/

--- a/.travis/push-to-dockerhub.sh
+++ b/.travis/push-to-dockerhub.sh
@@ -5,9 +5,8 @@ set -o nounset
 set -o pipefail
 
 version=`cat VERSION`
-docker tag projectriff/buildpack:latest projectriff/buildpack:${version}
-docker tag projectriff/buildpack:latest projectriff/buildpack:${version}-ci-${TRAVIS_COMMIT}
+docker tag projectriff/builder:latest projectriff/builder:${version}
+docker tag projectriff/builder:latest projectriff/builder:${version}-ci-${TRAVIS_COMMIT}
 
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
-docker push projectriff/buildpack:${version}
-docker push projectriff/buildpack:${version}-ci-${TRAVIS_COMMIT}
+docker push projectriff/builder

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = riff Buildpack Group
 
 This repository hosts the files necessary to create the buildpack builder used when
-riff builds functions from source with the `riff function create <buildpack> <fn-name>`
+riff builds functions from source with the `riff function create <fn-name>`
 command.
 
 == Relation to the https://github.com/projectriff/riff-buildpack[projectriff/riff-buildpack] Repository
@@ -9,34 +9,26 @@ In the v3 buildpack ecosystem, a distinction needs to be made between a _buildpa
 and a _builder_.
 
 The latter is what is actually involved when running `riff function create` with the
-`java` buildpack approach. A _builder_ is the composition of several _buildpacks_ using groups.
+buildpack approach. A _builder_ is the composition of several _buildpacks_ using groups.
 It takes the form of a docker image. In the case of riff, its official location is
-https://hub.docker.com/r/projectriff/buildpack/[projectriff/buildpack].
+https://hub.docker.com/r/projectriff/builder/[projectriff/builder].
 The purpose of this repository is to allow the creation of that builder.
 
 The former, a _buildpack_, is a more fine grained unit of logic that can be composed and
 collaborate with other buildpacks. The https://github.com/projectriff/riff-buildpack[projectriff/riff-buildpack]
 repository hosts one of them, responsible for applying the riff-specific logic on top of
-the more general java building logic. As more languages become supported by riff,
-that buildpack will evolve to collaborate with other buildpacks (_e.g._ `node`), while this
+the more general _java_ or _node_ building logic. As more languages become supported by riff,
+that buildpack will evolve to collaborate with other buildpacks (_e.g._ `python`), while this
 repository's `builder-riff.toml` file will enhance its group(s) to reference _e.g._ the generic
-`node` buildpack.
+`python` buildpack.
 
 == Building
 === Prerequisites
-To build the `projectriff/buildpack` builder you'll need
+To build the `projectriff/builder` builder you'll need
 
 * Go 1.11+
 * a running local docker daemon
-* the https://github.com/buildpack/pack[`pack`] command line tool. At the time of writing,
-a version built from `master` is required (to support references to remote buildpacks in `builder-riff.toml`):
-+
-[source,bash]
-----
-git clone https://github.com/buildpack/pack
-cd pack
-GO111MODULE=on go install ./cmd/pack
-----
+* the https://github.com/buildpack/pack[`pack`] command line tool, https://github.com/buildpack/pack/releases[version] `>= 0.0.5`.
 
 === Creating the Builder
 Then, building the builder is as simple as
@@ -44,7 +36,7 @@ Then, building the builder is as simple as
 ----
 git clone https://github.com/projectriff/riff-buildpack-group
 cd riff-buildpack-group
-pack create-builder -b builder-riff.toml projectriff/buildpack
+pack create-builder -b builder-riff.toml projectriff/builder
 ----
 
 === Using the Builder Locally
@@ -52,7 +44,7 @@ Lastly, to use the builder created above, just refer to the `pack build` referen
 [source, bash]
 ----
 cd where-your-function-is
-pack build --builder projectriff/buildpack --no-pull -p . your-org/my-function
+pack build --builder projectriff/builder --no-pull -p . your-org/my-function
 ----
 
 You should get something similar to

--- a/riff-cnb-buildtemplate.yaml
+++ b/riff-cnb-buildtemplate.yaml
@@ -44,11 +44,11 @@ spec:
           mountPath: /cache
       imagePullPolicy: Always
     - name: write-riff-toml
-      image: projectriff/buildpack:latest
+      image: projectriff/builder:latest
       command: ["/bin/bash", "-c", "printf \"artifact = '${FUNCTION_ARTIFACT}'\\nhandler = '${FUNCTION_HANDLER}'\\noverride = '${FUNCTION_LANGUAGE}'\\n\" > app/riff.toml"]
       imagePullPolicy: Always
     - name: detect
-      image: projectriff/buildpack:latest
+      image: projectriff/builder:latest
       command: ["/lifecycle/detector"]
       imagePullPolicy: Always
     - name: analyze
@@ -60,7 +60,7 @@ spec:
           value: ${USE_CRED_HELPERS}
       imagePullPolicy: Always
     - name: build
-      image: projectriff/buildpack:latest
+      image: projectriff/builder:latest
       command: ["/lifecycle/builder"]
       volumeMounts:
         - name: app-cache


### PR DESCRIPTION
Re-instantitate use of the `latest` tag (as well as snapshoted tags as before)

Fixes #6