### PR TITLE
Upgrade to pack@0.0.8 and compatible language BPs.

### DIFF
--- a/.travis/install-pack.sh
+++ b/.travis/install-pack.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-wget -qO- https://github.com/buildpack/pack/releases/download/v0.0.5/pack-0.0.5-linux.tar.gz | tar xvz -C $HOME/bin
+wget -qO- https://github.com/buildpack/pack/releases/download/v0.0.8/pack-0.0.8-linux.tar.gz | tar xvz -C $HOME/bin
 export PATH="$HOME/bin:$PATH"
 

--- a/builder-riff.toml
+++ b/builder-riff.toml
@@ -4,40 +4,40 @@ uri = "https://storage.googleapis.com/projectriff/riff-buildpack/latest.tgz"
 
 [[buildpacks]]
 id = "org.cloudfoundry.buildsystem"
-uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/buildsystem/org.cloudfoundry.buildsystem/1.0.0-M1/org.cloudfoundry.buildsystem-1.0.0-M1.tgz"
+uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/buildsystem/org.cloudfoundry.buildsystem/1.0.0-M3/org.cloudfoundry.buildsystem-1.0.0-M3.tgz"
 
 [[buildpacks]]
 id = "org.cloudfoundry.openjdk"
-uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/openjdk/org.cloudfoundry.openjdk/1.0.0-M1/org.cloudfoundry.openjdk-1.0.0-M1.tgz"
+uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/openjdk/org.cloudfoundry.openjdk/1.0.0-M3/org.cloudfoundry.openjdk-1.0.0-M3.tgz"
 
 [[buildpacks]]
 id = "org.cloudfoundry.buildpacks.nodejs"
-uri = "https://github.com/cloudfoundry/nodejs-cnb/releases/download/v0.0.1-alpha/nodejs-cnb.tgz"
+uri = "https://github.com/cloudfoundry/nodejs-cnb/releases/download/v0.0.2/nodejs-cnb.tgz"
 
 [[buildpacks]]
 id = "org.cloudfoundry.buildpacks.npm"
-uri = "https://storage.googleapis.com/projectriff/npm-buildpack/npm-cnb-c1b7bcfe0d.tgz"
+uri = "https://github.com/cloudfoundry/npm-cnb/releases/download/v0.0.3/npm-cnb.tgz"
 
 [[groups]]
 
   [[groups.buildpacks]]
   id = "org.cloudfoundry.openjdk"
-  version = "1.0.0-M1"
+  version = "1.0.0-M3"
   optional = true # Irrelevant as this buildpack's detect is a noop, but set for clarity
 
   [[groups.buildpacks]]
   id = "org.cloudfoundry.buildpacks.nodejs"
-  version = "0.0.1"
+  version = "0.0.2"
   optional = true # Irrelevant as this buildpack's detect is a noop, but set for clarity
 
   [[groups.buildpacks]]
   id = "org.cloudfoundry.buildsystem"
-  version = "1.0.0-M1"
+  version = "1.0.0-M3"
   optional = true
 
   [[groups.buildpacks]]
   id = "org.cloudfoundry.buildpacks.npm"
-  version = "0.0.1"
+  version = "0.0.3"
   optional = true
 
   [[groups.buildpacks]]

--- a/builder-riff.toml
+++ b/builder-riff.toml
@@ -16,7 +16,7 @@ uri = "https://github.com/cloudfoundry/nodejs-cnb/releases/download/v0.0.2/nodej
 
 [[buildpacks]]
 id = "org.cloudfoundry.buildpacks.npm"
-uri = "https://github.com/cloudfoundry/npm-cnb/releases/download/v0.0.3/npm-cnb.tgz"
+uri = "https://storage.googleapis.com/projectriff/npm-buildpack/npm-cnb-5c4c6ec2280.tgz"
 
 [[groups]]
 

--- a/riff-cnb-buildtemplate.yaml
+++ b/riff-cnb-buildtemplate.yaml
@@ -30,7 +30,7 @@ spec:
       description: Explicit language to use for the function, will skip detection.
     - name: RUN_IMAGE
       description: The run image buildpacks will use as the base for IMAGE.
-      default: packs/run
+      default: packs/run:v3alpha2
     - name: USE_CRED_HELPERS
       description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
       default: 'true'


### PR DESCRIPTION
Fixes #16

Depends on projectriff/riff-buildpack#41

Some changes in behavior I detected:
- JVM builds: requires language level be set >= 6 (see https://github.com/projectriff-samples/java-hello/commit/96ab2225dfb1f20e63f2ff2927e1bbbcdef3aecb I had to do to make that function pass for example)
- NPM builds: the `node_modules` directory is **required**.  see https://github.com/cloudfoundry/npm-cnb/issues/5
