### PR TITLE
Restore unversioned builttemplate yaml

### DIFF
--- a/.travis/push-buildtemplate-to-gcs.sh
+++ b/.travis/push-buildtemplate-to-gcs.sh
@@ -15,3 +15,4 @@ sed "s|projectriff/builder:latest|projectriff/builder:${version}|" riff-cnb-buil
 
 gsutil cp -a public-read riff-cnb-buildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/
 gsutil cp -a public-read riff-cnb-buildtemplate-${version}.yaml gs://projectriff/riff-buildtemplate/
+gsutil cp -a public-read riff-cnb-buildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml


### PR DESCRIPTION
The content of the file is pinned to a specific image as the :latest tag
is no longer published.

Refs #18 