### PR TITLE
Switch riff BuildTemplate to be cluster scoped

### DIFF
--- a/.travis/push-buildtemplate-to-gcs.sh
+++ b/.travis/push-buildtemplate-to-gcs.sh
@@ -10,9 +10,13 @@ CI_TAG="${version}-ci-${id}"
 
 gcloud auth activate-service-account --key-file <(echo $GCLOUD_CLIENT_SECRET | base64 --decode)
 
-sed "s|projectriff/builder:latest|projectriff/builder:${CI_TAG}|" riff-cnb-buildtemplate.yaml > riff-cnb-buildtemplate-${CI_TAG}.yaml
-sed "s|projectriff/builder:latest|projectriff/builder:${version}|" riff-cnb-buildtemplate.yaml > riff-cnb-buildtemplate-${version}.yaml
+sed "s|projectriff/builder:latest|projectriff/builder:${CI_TAG}|" riff-cnb-clusterbuildtemplate.yaml > riff-cnb-clusterbuildtemplate-${CI_TAG}.yaml
+sed "s|projectriff/builder:latest|projectriff/builder:${version}|" riff-cnb-clusterbuildtemplate.yaml > riff-cnb-clusterbuildtemplate-${version}.yaml
 
-gsutil cp -a public-read riff-cnb-buildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/
-gsutil cp -a public-read riff-cnb-buildtemplate-${version}.yaml gs://projectriff/riff-buildtemplate/
-gsutil cp -a public-read riff-cnb-buildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml
+gsutil cp -a public-read riff-cnb-clusterbuildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/
+gsutil cp -a public-read riff-cnb-clusterbuildtemplate-${version}.yaml gs://projectriff/riff-buildtemplate/
+gsutil cp -a public-read riff-cnb-clusterbuildtemplate-${CI_TAG}.yaml gs://projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml
+
+gsutil cp -a public-read riff-cnb-cache.yaml gs://projectriff/riff-buildtemplate/riff-cnb-cache-${CI_TAG}.yaml
+gsutil cp -a public-read riff-cnb-cache.yaml gs://projectriff/riff-buildtemplate/riff-cnb-cache-${version}.yaml
+gsutil cp -a public-read riff-cnb-cache.yaml gs://projectriff/riff-buildtemplate/

--- a/riff-cnb-cache.yaml
+++ b/riff-cnb-cache.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: riff-cnb-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -1,17 +1,5 @@
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: riff-cnb-cache
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 8Gi
----
 apiVersion: build.knative.dev/v1alpha1
-kind: BuildTemplate
+kind: ClusterBuildTemplate
 metadata:
   name: riff-cnb
 spec:


### PR DESCRIPTION
Knative supports both BuildTemplate and ClusterBuildTemplate resources.
The advantage of the ClusterBuildTemplate is that it can be maintained
and upgraded as part of riff.

Currently, the template is deployed in each namespace and there is no
mechanism to maintain the template.

This PR also splits out the build cache from the build template. The
cache and service account will still need to be created in each
namespace where builds will run.

There will be a coresponding PR in riff to pull in these changes.

Refs projectriff/riff#968