### PR TITLE
[DNM] Prevent RUN_IMAGE from being overridden in build template

### DIFF
--- a/riff-cnb-buildtemplate.yaml
+++ b/riff-cnb-buildtemplate.yaml
@@ -28,9 +28,6 @@ spec:
     - name: FUNCTION_LANGUAGE
       default: ""
       description: Explicit language to use for the function, will skip detection.
-    - name: RUN_IMAGE
-      description: The run image buildpacks will use as the base for IMAGE.
-      default: packs/run:v3alpha2
     - name: USE_CRED_HELPERS
       description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
       default: 'true'
@@ -72,7 +69,7 @@ spec:
       args: ["${IMAGE}"]
       env:
         - name: PACK_RUN_IMAGE
-          value: ${RUN_IMAGE}
+          value: packs/run:v3alpha2
         - name: PACK_USE_HELPERS
           value: ${USE_CRED_HELPERS}
       imagePullPolicy: Always


### PR DESCRIPTION
The build template parameter `RUN_IMAGE` no longer needs to be overrideable now that PR https://github.com/projectriff/riff/pull/1082 is merged. This PR makes sure the default value cannot be overridden.

Downsides of this PR are:
* the default value is now coded later in the YAML and a developer might overlook that
* the image detection logic will need updating to relocate the hard-coded image

Ref https://github.com/projectriff/riff/issues/1081