### PR TITLE
Parameterize builder and util images in build template

### DIFF
--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -22,54 +22,82 @@ spec:
     - name: BUILDER_IMAGE
       description: The builder image provides the buildpacks that will build the IMAGE from source.
       default: projectriff/builder:latest
-    - name: UTIL_IMAGE
-      description: The util image provides pack utilities to analyze and export built images.
-      default: packs/util
     - name: USE_CRED_HELPERS
       description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
       default: 'true'
+    - name: USER_ID
+      description: The user ID of the builder image user
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user
+      default: "1000"
   steps:
     - name: prepare
-      image: ${UTIL_IMAGE}
-      command: ["/lifecycle/knative-helper"]
+      image: ubuntu:18.04
+      command: ["/bin/sh"]
+      args:
+        - "-c"
+        - >
+          chown -R "${USER_ID}:${GROUP_ID}" "/builder/home" &&
+          chown -R "${USER_ID}:${GROUP_ID}" /layers &&
+          echo "artifact = '${FUNCTION_ARTIFACT}'" > /workspace/riff.toml &&
+          echo "handler = '${FUNCTION_HANDLER}'" >> /workspace/riff.toml &&
+          echo "override = '${FUNCTION_LANGUAGE}'" >> /workspace/riff.toml
       volumeMounts:
-        - name: app-cache
-          mountPath: /cache
-      imagePullPolicy: Always
-    - name: write-riff-toml
-      image: ${UTIL_IMAGE}
-      command: ["/bin/bash", "-c", "printf \"artifact = '${FUNCTION_ARTIFACT}'\\nhandler = '${FUNCTION_HANDLER}'\\noverride = '${FUNCTION_LANGUAGE}'\\n\" > app/riff.toml"]
+        - name: cache
+          mountPath: /layers
       imagePullPolicy: Always
     - name: detect
       image: ${BUILDER_IMAGE}
       command: ["/lifecycle/detector"]
+      args:
+        - "-app=/workspace"
+        - "-group=/layers/group.toml"
+        - "-plan=/layers/plan.toml"
+      volumeMounts:
+        - name: cache
+          mountPath: /layers
       imagePullPolicy: Always
     - name: analyze
-      image: ${UTIL_IMAGE}
+      image: ${BUILDER_IMAGE}
       command: ["/lifecycle/analyzer"]
-      args: ["${IMAGE}"]
-      env:
-        - name: PACK_USE_HELPERS
-          value: ${USE_CRED_HELPERS}
+      args:
+        - "-layers=/layers"
+        - "-helpers=${USE_CRED_HELPERS}"
+        - "-group=/layers/group.toml"
+        - "${IMAGE}"
+      volumeMounts:
+        - name: cache
+          mountPath: /layers
       imagePullPolicy: Always
     - name: build
       image: ${BUILDER_IMAGE}
       command: ["/lifecycle/builder"]
+      args:
+        - "-layers=/layers"
+        - "-app=/workspace"
+        - "-group=/layers/group.toml"
+        - "-plan=/layers/plan.toml"
       volumeMounts:
-        - name: app-cache
-          mountPath: /cache
+        - name: cache
+          mountPath: /layers
       imagePullPolicy: Always
     - name: export
-      image: ${UTIL_IMAGE}
+      image: ${BUILDER_IMAGE}
       command: ["/lifecycle/exporter"]
       args: ["${IMAGE}"]
-      env:
-        - name: PACK_RUN_IMAGE
-          value: ${RUN_IMAGE}
-        - name: PACK_USE_HELPERS
-          value: ${USE_CRED_HELPERS}
+      args:
+        - "-layers=/layers"
+        - "-helpers=${USE_CRED_HELPERS}"
+        - "-app=/workspace"
+        - "-image=${RUN_IMAGE}"
+        - "-group=/layers/group.toml"
+        - "${IMAGE}"
+      volumeMounts:
+        - name: cache
+          mountPath: /layers
       imagePullPolicy: Always
   volumes:
-    - name: app-cache
+    - name: cache
       persistentVolumeClaim:
         claimName: riff-cnb-cache

--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -37,6 +37,8 @@ spec:
       command: ["/bin/sh"]
       args:
         - "-c"
+        # Change owner of files to the pack user so that later lifecycle comamnds can read them.
+        # Generate riff.toml
         - >
           chown -R "${USER_ID}:${GROUP_ID}" "/builder/home" &&
           chown -R "${USER_ID}:${GROUP_ID}" /layers &&

--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -19,28 +19,33 @@ spec:
     - name: RUN_IMAGE
       description: The run image buildpacks will use as the base for IMAGE.
       default: packs/run:v3alpha2
+    - name: BUILDER_IMAGE
+      description: The builder image provides the buildpacks that will build the IMAGE from source.
+      default: projectriff/builder:latest
+    - name: UTIL_IMAGE
+      description: The util image provides pack utilities to analyze and export built images.
+      default: packs/util
     - name: USE_CRED_HELPERS
       description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
       default: 'true'
-
   steps:
     - name: prepare
-      image: packs/base
+      image: ${UTIL_IMAGE}
       command: ["/lifecycle/knative-helper"]
       volumeMounts:
         - name: app-cache
           mountPath: /cache
       imagePullPolicy: Always
     - name: write-riff-toml
-      image: projectriff/builder:latest
+      image: ${UTIL_IMAGE}
       command: ["/bin/bash", "-c", "printf \"artifact = '${FUNCTION_ARTIFACT}'\\nhandler = '${FUNCTION_HANDLER}'\\noverride = '${FUNCTION_LANGUAGE}'\\n\" > app/riff.toml"]
       imagePullPolicy: Always
     - name: detect
-      image: projectriff/builder:latest
+      image: ${BUILDER_IMAGE}
       command: ["/lifecycle/detector"]
       imagePullPolicy: Always
     - name: analyze
-      image: packs/util
+      image: ${UTIL_IMAGE}
       command: ["/lifecycle/analyzer"]
       args: ["${IMAGE}"]
       env:
@@ -48,14 +53,14 @@ spec:
           value: ${USE_CRED_HELPERS}
       imagePullPolicy: Always
     - name: build
-      image: projectriff/builder:latest
+      image: ${BUILDER_IMAGE}
       command: ["/lifecycle/builder"]
       volumeMounts:
         - name: app-cache
           mountPath: /cache
       imagePullPolicy: Always
     - name: export
-      image: packs/util
+      image: ${UTIL_IMAGE}
       command: ["/lifecycle/exporter"]
       args: ["${IMAGE}"]
       env:
@@ -64,7 +69,6 @@ spec:
         - name: PACK_USE_HELPERS
           value: ${USE_CRED_HELPERS}
       imagePullPolicy: Always
-
   volumes:
     - name: app-cache
       persistentVolumeClaim:


### PR DESCRIPTION
The builder template is used twice within the build template, as is the
util image. We can centralize the definition of the builder image by
using a parameter. In general, builds should not override the run or
builder image params. It is still useful to parameterize them in order
to make it easier for tooling to discover or update the value cluster
wide.

Refs #22