### PR TITLE
Disable build cache

### DIFF
--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -102,5 +102,7 @@ spec:
       imagePullPolicy: Always
   volumes:
     - name: cache
-      persistentVolumeClaim:
-        claimName: riff-cnb-cache
+      emptyDir: {}
+      # TODO reenable build cache once knative/build#542 is fixed
+      #persistentVolumeClaim:
+      #  claimName: riff-cnb-cache


### PR DESCRIPTION
Knative Build 0.3 can produce duplicate build pods which both have the
cache volume mounted in RW mode. Two builds interacting with the cache
at the same time can cause the build to fail.

Slow builds are better than failing builds.

We can reenable the cache with the next version of Knative Build.

Refs knative/build#542