### PR TITLE
Drop riff.toml for function config

### DIFF
--- a/.travis/install-pack.sh
+++ b/.travis/install-pack.sh
@@ -9,4 +9,4 @@ set -o pipefail
 # export PATH="$HOME/bin:$PATH"
 
 # master as of 2019-03-21
-GO111MODULE=on go get github.com/buildpack/pack/cmd/pack@40640e5370f31452b955e8aa538e4d1c67b34d9c
+GO111MODULE=on go get github.com/buildpack/pack/cmd/pack@ebc7c99fc236c4757c6138dfe9234e575f56fb18

--- a/riff-cnb-clusterbuildtemplate.yaml
+++ b/riff-cnb-clusterbuildtemplate.yaml
@@ -40,15 +40,10 @@ spec:
       command: ["/bin/sh"]
       args:
         - "-c"
-        # Change owner of files to the pack user so that later lifecycle comamnds can read them.
-        # Generate riff.toml
         - >
           chown -R "${USER_ID}:${GROUP_ID}" "/builder/home" &&
           chown -R "${USER_ID}:${GROUP_ID}" /layers &&
-          chown -R "${USER_ID}:${GROUP_ID}" /workspace &&
-          echo "artifact = '${FUNCTION_ARTIFACT}'" > /workspace/riff.toml &&
-          echo "handler = '${FUNCTION_HANDLER}'" >> /workspace/riff.toml &&
-          echo "override = '${FUNCTION_LANGUAGE}'" >> /workspace/riff.toml
+          chown -R "${USER_ID}:${GROUP_ID}" /workspace
       volumeMounts:
         - name: ${CACHE}
           mountPath: /layers
@@ -60,6 +55,15 @@ spec:
         - "-app=/workspace"
         - "-group=/layers/group.toml"
         - "-plan=/layers/plan.toml"
+      env:
+      - name: RIFF
+        value: "true"
+      - name: RIFF_ARTIFACT
+        value: ${FUNCTION_ARTIFACT}
+      - name: RIFF_HANDLER
+        value: ${FUNCTION_HANDLER}
+      - name: RIFF_OVERRIDE
+        value: ${FUNCTION_LANGUAGE}
       volumeMounts:
         - name: ${CACHE}
           mountPath: /layers
@@ -84,6 +88,15 @@ spec:
         - "-app=/workspace"
         - "-group=/layers/group.toml"
         - "-plan=/layers/plan.toml"
+      env:
+      - name: RIFF
+        value: "true"
+      - name: RIFF_ARTIFACT
+        value: ${FUNCTION_ARTIFACT}
+      - name: RIFF_HANDLER
+        value: ${FUNCTION_HANDLER}
+      - name: RIFF_OVERRIDE
+        value: ${FUNCTION_LANGUAGE}
       volumeMounts:
         - name: ${CACHE}
           mountPath: /layers


### PR DESCRIPTION
Use environment variables instead, now that the function buildpacks are
able to be configured with either riff.toml or environment variables.

Refs projectriff/riff#1192