### PR TITLE
Updates FATS to latest

### DIFF
--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -34,7 +34,8 @@ import (
 )
 
 type testcases struct {
-	Testcases []testcase `toml:"Testcases"`
+	Common    testcase   `toml:"common"`
+	Testcases []testcase `toml:"testcases"`
 }
 
 type testcase struct {
@@ -48,10 +49,49 @@ type testcase struct {
 	SkipRebuild bool   `toml:"skip-rebuild"`
 }
 
+func (t testcase) merge(c testcase) testcase {
+	t.metadata = t.metadata.merge(c.metadata)
+
+	if t.Repo == "" {
+		t.Repo = c.Repo
+	}
+	if t.Refspec == "" {
+		t.Refspec = c.Refspec
+	}
+	if t.SubPath == "" {
+		t.SubPath = c.SubPath
+	}
+	if t.ContentType == "" {
+		t.ContentType = c.ContentType
+	}
+	if t.Input == "" {
+		t.Input = c.Input
+	}
+	if t.Output == "" {
+		t.Output = c.Output
+	}
+
+	return t
+}
+
 type metadata struct {
 	Artifact string `toml:"artifact"`
 	Handler  string `toml:"handler"`
 	Override string `toml:"override"`
+}
+
+func (m metadata) merge(c metadata) metadata {
+	if m.Artifact == "" {
+		m.Artifact = c.Artifact
+	}
+	if m.Handler == "" {
+		m.Handler = c.Handler
+	}
+	if m.Override == "" {
+		m.Override = c.Override
+	}
+
+	return m
 }
 
 func main() {
@@ -64,6 +104,7 @@ func main() {
 	}
 
 	for _, t := range tests.Testcases {
+		t = t.merge(tests.Common)
 		appdir, err := ioutil.TempDir("", "riff-buildpack-group-")
 		if err != nil {
 			log.Fatalf("could not create temp dir: %v", err)

--- a/integration-tests/tests.toml
+++ b/integration-tests/tests.toml
@@ -1,43 +1,22 @@
-[[testcases]]
+[common]
 repo = "https://github.com/projectriff/fats"
-refspec = "9a3c6ed1c184ab37a0651b977d1d7d8f0a62cf07"
+refspec = "c346e1687dc635602552dd864e133feb1dea547f"
+input = "builder"
+content-type = "text/plain"
+output = "BUILDER"
+
+[[testcases]]
 sub-path = "functions/uppercase/java"
-handler = "functions.Upper"
-input = "builder"
-content-type = "text/plain"
-output = "BUILDER"
 
 [[testcases]]
-repo = "https://github.com/projectriff/fats"
-refspec = "9a3c6ed1c184ab37a0651b977d1d7d8f0a62cf07"
 sub-path = "functions/uppercase/java-boot"
-input = "builder"
-content-type = "text/plain"
-output = "BUILDER"
 
 [[testcases]]
-repo = "https://github.com/projectriff/fats"
-refspec = "9a3c6ed1c184ab37a0651b977d1d7d8f0a62cf07"
 sub-path = "functions/uppercase/node"
-artifact = "uppercase.js"
-input = "builder"
-content-type = "text/plain"
-output = "BUILDER"
 
 [[testcases]]
-repo = "https://github.com/projectriff/fats"
-refspec = "9a3c6ed1c184ab37a0651b977d1d7d8f0a62cf07"
 sub-path = "functions/uppercase/npm"
-input = "builder"
-content-type = "text/plain"
-output = "BUILDER"
 skip-rebuild = true
 
 [[testcases]]
-repo = "https://github.com/projectriff/fats"
-refspec = "9a3c6ed1c184ab37a0651b977d1d7d8f0a62cf07"
 sub-path = "functions/uppercase/command"
-artifact = "uppercase.sh"
-input = "builder"
-content-type = "text/plain"
-output = "BUILDER"


### PR DESCRIPTION
FATS functions now include a riff.toml file that contains the handler
and artifact values, so we no longer need to specify them. It also drys
up the testcase config by pulling shared values into a common testcase
that is merged into every other testcase.